### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -45,6 +48,8 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jpvmrcd/calendar/security/code-scanning/1](https://github.com/jpvmrcd/calendar/security/code-scanning/1)

To fix the issue, we need to explicitly define permissions for the workflow and its jobs. The permissions should be set to the least privilege required for the tasks performed in each job. 

1. Add a `permissions` block at the root level of the workflow to set default permissions for all jobs. For example, `contents: read` is sufficient for most CI workflows.
2. For jobs that require additional permissions (e.g., `publish-npm`), define specific permissions within the job to allow only the necessary actions (e.g., `contents: write` for publishing packages).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
