### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -45,6 +47,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jpvmrcd/calendar/security/code-scanning/2](https://github.com/jpvmrcd/calendar/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow:
1. The `build` job primarily runs tests and interacts with the repository contents, so it only needs `contents: read`.
2. The `publish-npm` job publishes packages and interacts with secrets, so it needs `contents: read` and `packages: write`.

The `permissions` block can be added at the job level for each job (`build` and `publish-npm`) to ensure least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
