### PR TITLE
chore: update npm-publish.yml to include id-token permission

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,6 +50,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write  # Required for OIDC
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v4


### PR DESCRIPTION
Added id-token permission for OIDC in npm-publish workflow